### PR TITLE
readme: fix nix-env command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Interactively browse the dependency graph of your Nix derivations.
 ## Installation
 
 ```
-nix-env -i https://github.com/utdemir/nixdu/archive/master.tar.gz -A exe
+nix-env -iA exe -f https://github.com/utdemir/nixdu/archive/master.tar.gz
 ```
 
 ## Usage


### PR DESCRIPTION
```
The nix-env based install command specified in the README file is
failing.

$ nix-env -i https://github.com/utdemir/nixdu/archive/master.tar.gz -A exe
error: attribute 'https://github' in selection path 'https://github.com/utdemir/nixdu/archive/master.tar.gz' not found
```

PS: first!